### PR TITLE
Add the original shortcut to the custom play scene button

### DIFF
--- a/addons/fabianlc_custom_play_scene_button/plugin.cfg
+++ b/addons/fabianlc_custom_play_scene_button/plugin.cfg
@@ -9,5 +9,5 @@ to make sure playing a scene from the editor is the same as loading
 it normally in the game.
 "
 author="Fabián L.C."
-version="0.1"
+version="0.2"
 script="plugin.gd"

--- a/addons/fabianlc_custom_play_scene_button/plugin.gd
+++ b/addons/fabianlc_custom_play_scene_button/plugin.gd
@@ -42,6 +42,9 @@ func _enter_tree():
 		custom_play_button.focus_mode = Control.FOCUS_NONE
 		custom_play_button.toggle_mode = false
 
+		if is_instance_valid(old_play_button):
+			custom_play_button.shortcut = old_play_button.shortcut
+
 		var prt = main_play_button.get_parent()
 		prt.add_child(custom_play_button)
 		var play_signal = main_play_button.get_meta("play_signal")


### PR DESCRIPTION
This adds the shortcut from the original play scene button to the custom button.